### PR TITLE
Add OpenClacky to Code Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 - [Kiro](https://kiro.dev/) — AWS's spec-driven AI coding IDE. Three-phase Specify, Plan, Execute workflow.
 - [mini-coding-agent](https://github.com/rasbt/mini-coding-agent) — Sebastian Raschka's minimal, readable Python coding agent harness. Explains the core components of coding agents in a small, hackable codebase.
 - [OpenCode](https://github.com/opencode-ai/opencode) — Open-source terminal-native AI coding agent built in Go by SST. 160K+ stars, 7.5M monthly developers. Works in terminal, IDE, or desktop with any LLM.
+- [OpenClacky](https://openclacky.com) — The most token-efficient open-source AI agent. Achieves **93.8% 7-day Prompt Cache hit rate** via frozen system prompts, dual cache markers, and idle-time context compression — Claude Code-class task execution at ~0.8× the cost. BYOK, 16 core tools, Skill extensions, IM integrations (Feishu, WeCom, Discord, Telegram), browser automation, cron tasks. MIT, local-first.
 - [Open SWE](https://github.com/langchain-ai/open-swe) — LangChain's open-source async cloud coding agent. Connects to GitHub repos, delegates tasks from issues via Slack or Linear.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) — AI software development agent (formerly OpenDevin).
 - [OpenHands Software Agent SDK](https://github.com/OpenHands/software-agent-sdk) — Modular Python SDK for building code agents. Local or ephemeral workspaces, composable tools, powers OpenHands CLI and Cloud.


### PR DESCRIPTION
## Adding OpenClacky to Code Agents section

**[OpenClacky](https://openclacky.com)** — The most token-efficient open-source AI agent.

Most AI agents silently burn tokens by re-sending the same system prompt and tool schema on every single turn. OpenClacky attacks this at the architecture level:

- Frozen system prompts + dual cache markers = Prompt Cache always hits
- Insert-then-Compress: new context is appended first, then compressed during idle time
- Stable 16-tool schema across all sessions
- Result: **93.8% 7-day global Prompt Cache hit rate**, publicly tracked

**Benchmark**: Claude Code-class task quality at **~0.8× the cost**. (Claude Code = 1.0×, OpenClaw ≈ 1.5×, Hermes ≈ 3–4×)

**Key features:**
- MIT licensed, local-first, no telemetry
- BYOK: Claude, GPT, DeepSeek, Kimi, Gemini, Minimax, OpenRouter, any OpenAI-compatible API
- 16 core tools (files, terminal, search, browser, task manager) + Skill extensions
- IM integrations: Feishu, WeCom, Discord, Telegram, DingTalk
- Browser automation via Chrome DevTools Protocol
- Scheduled (cron) tasks, long-term memory

GitHub: https://github.com/clacky-ai/open-clacky

Entry placed alphabetically between OpenCode and Open SWE.