### PR TITLE
Add Hermes to Platforms & Low-Code

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 - [Composio](https://github.com/ComposioHQ/composio) — 1000+ toolkits, auth management, and sandboxed workbench for AI agents.
 - [Dify](https://github.com/langgenius/dify) — Open-source LLMOps platform with visual agent builder.
 - [Google Vertex AI Agent Builder](https://cloud.google.com/vertex-ai/docs/agents) — Google Cloud's agent development platform.
+- [Hermes](https://buildwithhermes.com) — Voice AI agent platform for agencies: white-label deployment, native CRM, inbound/outbound campaign orchestration, and usage-based billing on one system.
 - [MaxKB](https://github.com/1Panel-dev/MaxKB) — Open-source platform for building enterprise-grade agents.
 - [Microsoft Copilot Studio](https://copilotstudio.microsoft.com/) — Low-code agent builder. Integrates with M365, Dynamics, Power Platform.
 - [n8n](https://n8n.io/) — Workflow automation with native AI agent capabilities and MCP support.


### PR DESCRIPTION
This PR adds Hermes (buildwithhermes.com) to the Platforms & Low-Code section, inserted alphabetically after Google Vertex AI Agent Builder.

Hermes is a commercial platform for building and operating real-time voice AI agents, aimed at agencies running agents for multiple clients. It covers agent building, campaign orchestration (inbound/outbound calling), a native CRM, and usage-based billing in one system, with white-label deployment.

It complements the existing entries: most platforms listed (Relevance AI, Copilot Studio, Dify) focus on chat/workflow agents; Hermes covers the telephony/voice agent side with multi-tenant operations.

Format matches the list style. Happy to adjust wording or placement.