### PR TITLE
Add Proliferate to Code Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 - [Open SWE](https://github.com/langchain-ai/open-swe) — LangChain's open-source async cloud coding agent. Connects to GitHub repos, delegates tasks from issues via Slack or Linear.
 - [OpenHands](https://github.com/All-Hands-AI/OpenHands) — AI software development agent (formerly OpenDevin).
 - [OpenHands Software Agent SDK](https://github.com/OpenHands/software-agent-sdk) — Modular Python SDK for building code agents. Local or ephemeral workspaces, composable tools, powers OpenHands CLI and Cloud.
+- [Proliferate](https://proliferate.com/) — Open-source local and cloud agent IDE with parallel workspaces, subagents, plugins, and MCP.
 - [Qwen Code](https://github.com/QwenLM/qwen-code) — Alibaba's open-source terminal-native AI coding agent. Powered by Qwen models with MCP support, 25K+ stars, and Apache-2.0 license.
 - [SWE-agent](https://github.com/princeton-nlp/SWE-agent) — Princeton's software engineering agent.
 - [Windsurf](https://windsurf.com/) — AI-native IDE by Codeium with agentic Cascade flows.


### PR DESCRIPTION
Adds Proliferate to the Code Agents section in alphabetical order.

Why it fits:
- open-source local and cloud agent IDE
- focused on coding-agent workflows with parallel workspaces, subagents, plugins, and MCP
- repository currently has 100+ stars

Source:
- https://github.com/proliferate-ai/proliferate
- https://proliferate.com/docs