### PR TITLE
Add ClawBench to Evaluation & Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 
 - [AgentBench](https://github.com/THUDM/AgentBench) — Tsinghua's multi-dimensional agent benchmark.
 - [AgentBoard](https://github.com/hkust-nlp/AgentBoard) — Multi-round agent evaluation platform.
+- [ClawBench](https://github.com/reacher-z/ClawBench) — Live-site benchmark for browser agents completing everyday online workflows.
 - [GAIA](https://huggingface.co/gaia-benchmark) — General AI Assistants benchmark by Meta.
 - [LangTest](https://github.com/Pacific-AI-Corp/langtest) — Testing framework for delivering safe & effective language models.
 - [RuLES](https://github.com/normster/llm_rules) — Benchmark for evaluating rule-following in language models.


### PR DESCRIPTION
Disclosure: I am a ClawBench maintainer.

## Summary

Adds ClawBench to **Evaluation & Testing**, between AgentBoard and GAIA to preserve alphabetical order. ClawBench is an actively maintained live-site benchmark for browser agents, and the project exceeds the contribution guide's 100-star threshold.

The list description is nine words, below the 15-word limit.

## Links

- Project: https://claw-bench.com/
- Paper: https://arxiv.org/abs/2604.08523
- GitHub: https://github.com/reacher-z/ClawBench

## Validation

- Searched the full default branch for `ClawBench`, `2604.08523`, and `claw-bench.com`; no existing entry was found.
- Checked all pull-request states for the same identifiers and prior `reacher-z` submissions; no match was found.
- Verified alphabetical placement, working links, and a clean `git diff --check`.
