### PR TITLE
Add Octochains to Multi-Agent Orchestration

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,12 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 - [Omnigent](https://github.com/omnigent-ai/omnigent) — Open-source meta-harness that orchestrates Claude Code, Codex, Cursor, OpenCode, Hermes, and Pi under one policy/sandboxing layer. Cloud sandboxes (Modal, Daytona, E2B, Kubernetes, Databricks), live multi-device session sharing, and YAML-defined sub-agents. Apache-2.0.
 - [OpenAI Agents SDK](https://github.com/openai/openai-agents-python) — OpenAI's production framework for multi-agent orchestration with handoffs and guardrails.
 - [Orkas](https://github.com/Orkas-AI/Orkas) — Open-source desktop workspace for coordinating specialist AI agents in parallel or sequence.
+- [Octochains](https://github.com/ahmadvh/octochains) — Parallel isolated multi-agent reasoning with centralized  aggregation for high-stakes decision-making.
 - [Ruflo](https://github.com/ruvnet/ruflo) — Agent orchestration platform optimized for Claude. Features self-learning swarms, distributed intelligence, RAG integration, and native Claude Code/Codex integration. Formerly claude-flow.
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) — Microsoft's SDK for AI orchestration. Plugins, planners, and memory.
 - [Strands Agents](https://github.com/strands-agents/harness-sdk) — AWS's model-driven, open-source SDK for building production AI agents in Python and TypeScript. Any model, any cloud, with MCP support and 23M+ monthly PyPI downloads. Apache-2.0.
 - [Swarm](https://github.com/openai/swarm) — OpenAI's lightweight multi-agent framework (educational).
-- [Octochains](https://github.com/ahmadvh/octochains) — Parallel isolated multi-agent reasoning with centralized  aggregation for high-stakes decision-making.
+
 
 ### Single Agent
 - [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) — Anthropic's production SDK for building AI agents powered by Claude. Stateful sessions, tool execution, sandboxing, and streaming. Available in Python and [TypeScript](https://github.com/anthropics/claude-agent-sdk-typescript).

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 - [Semantic Kernel](https://github.com/microsoft/semantic-kernel) — Microsoft's SDK for AI orchestration. Plugins, planners, and memory.
 - [Strands Agents](https://github.com/strands-agents/harness-sdk) — AWS's model-driven, open-source SDK for building production AI agents in Python and TypeScript. Any model, any cloud, with MCP support and 23M+ monthly PyPI downloads. Apache-2.0.
 - [Swarm](https://github.com/openai/swarm) — OpenAI's lightweight multi-agent framework (educational).
+- [Octochains](https://github.com/ahmadvh/octochains) — Parallel isolated multi-agent reasoning with centralized  aggregation for high-stakes decision-making.
 
 ### Single Agent
 - [Claude Agent SDK](https://github.com/anthropics/claude-agent-sdk-python) — Anthropic's production SDK for building AI agents powered by Claude. Stateful sessions, tool execution, sandboxing, and streaming. Available in Python and [TypeScript](https://github.com/anthropics/claude-agent-sdk-typescript).


### PR DESCRIPTION
## Add: [Octochains](https://github.com/ahmadvh/octochains)

**Section:** Multi-Agent Orchestration
**Description:** Parallel isolated multi-agent reasoning with centralized  aggregation for high-stakes decision-making.

---
### Checklist
- [x] 100+ GitHub stars OR from a major organization
- [x] Actively maintained (updated within last 6 months)
- [x] Link works and is not behind a paywall
- [x] Description is concise (max ~15 words)
- [x] Correct alphabetical placement within the section
- [x] No duplicates (searched existing entries)
- [x] Dash style matches the list (use ` — ` between name and description)