### PR TITLE
Add OpenCandle to Research Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ AI Agents are autonomous systems that use LLMs to reason, plan, and take actions
 ### Research Agents
 - [GPT Researcher](https://github.com/assafelovic/gpt-researcher) — Autonomous agent for deep research on any topic using any LLM.
 - [autoresearch](https://github.com/karpathy/autoresearch) — Andrej Karpathy's open-source framework for running AI agents that autonomously conduct research on single-GPU model training experiments overnight.
+- [OpenCandle](https://github.com/Kahtaf/OpenCandle) — Evidence-first financial research agent with live market data, source traces, and local portfolios.
 - [Perplexica](https://github.com/ItzCrazyKns/Perplexica) — Open-source AI-powered answering engine (Perplexity alternative).
 
 ## Platforms & Low-Code


### PR DESCRIPTION
Adding [OpenCandle](https://github.com/Kahtaf/OpenCandle) to Research Agents, before Perplexica.

I built OpenCandle as a financial research agent that gathers live market data and keeps the source trace attached to its answers. It also stores watchlists, portfolios, and alerts locally. The repo is MIT licensed and actively maintained.

The README description is 13 words. I checked the placement, duplicate state, link, and `git diff --check`.

One caveat: OpenCandle does not meet the current 100-star requirement. I understand if you would rather close this and have me come back once it does.

Disclosure: I maintain OpenCandle.
